### PR TITLE
Dell EMC Unity V5 uses CAS for login and ssl certificate warning messages

### DIFF
--- a/dellemc-unity_storage/check_unity.py
+++ b/dellemc-unity_storage/check_unity.py
@@ -18,7 +18,8 @@
 import json, requests
 import argparse
 import sys
-
+import urllib3
+urllib3.disable_warnings()
 
 '''
 ## Nagios
@@ -488,6 +489,8 @@ def login(hostaddress, user, password):
 	if r.status_code == 200:
 		token  = r.headers['emc-csrf-token']
 		cookie = r.cookies
+		for history in r.history:
+			requests.cookies.merge_cookies(cookie,history.cookies)
 	else:
 		token  = 0
 		cookie = 0
@@ -555,7 +558,7 @@ def main():
 		if (module.lower() == 'uncommittedport'):
 			value, descid, desc = getUncommittedport(hostaddress, token, cookie)
 
-                s = logout(hostaddress, token, cookie)
+		s = logout(hostaddress, token, cookie)
 	else:
 		value  = 0
 		descid = 'COULD_NOT_LOGIN'
@@ -565,7 +568,7 @@ def main():
 	if (value or value == 0) and descid and desc:
 		s_nagios, s_msg1, s_msg2, s_val, s_exit = NagiosStatus(value, descid, desc)
 		print ('%s: %s,%s,%s' % (s_nagios,s_msg1,s_msg2,s_val))
-                sys.exit(s_exit)
+		sys.exit(s_exit)
 	sys.exit(0)
 
 


### PR DESCRIPTION
I noticed that in our Unity V5.0.0 the script was not working because it now uses CAS for login. 
The python requests library is succesfully following the redirects (from the loginSessionInfo page, to the CAS login and back to the loginSessionInfo) but on the last redirect, the object does not contain all the cookies, I added some code that merges the cookies received from the CAS login page too (row 492, 493)

My certificate is self signed so I kept getting warning messages from the urllib library, I removed these messages (row 21, 22)

I also had some errors regarding spaces/tabs .
this script now works on my environment (Dell EMC Unity softwre v 5.0.0, python 3.7.3, requests 2.22.0, urllib3 1.24.3)